### PR TITLE
Removed duplicate plugin

### DIFF
--- a/lua/plugins/catppuccin.lua
+++ b/lua/plugins/catppuccin.lua
@@ -1,6 +1,6 @@
-return 
-{ "catppuccin/nvim"},
-{
-name = "catppuccin", priority = 1000 
+return {
+  "catppuccin/nvim",
+  name = "catppuccin",
+  priority = 1000,
 }
 

--- a/lua/plugins/catpuccin.lua
+++ b/lua/plugins/catpuccin.lua
@@ -1,5 +1,0 @@
-return {
-  { "catppuccin/nvim", name = "catppuccin", priority = 1000 },
-
-}
-


### PR DESCRIPTION
Catppuccin had two files in `lua/plugins`: `catpuccin.lua` and `catppuccin.lua`. The former was misspelled, so I deleted it, and the latter was misformatted, causing errors at start-up. I reformatted it so it would work.