### PR TITLE
Adding Cmp-Adaptive-freq

### DIFF
--- a/lua/plugins/cmp-adaptive-freq.lua
+++ b/lua/plugins/cmp-adaptive-freq.lua
@@ -1,0 +1,7 @@
+return {
+	"TheShadowblast123/cmp-adaptive-freq",
+	dependencies = { "hrsh7th/nvim-cmp" },
+	config = function()
+		require("cmp-adaptive-freq").setup({})
+	end,
+}

--- a/lua/plugins/nvim-cmp.lua
+++ b/lua/plugins/nvim-cmp.lua
@@ -43,6 +43,7 @@ return {
         { name = "luasnip" }, -- snippets
         { name = "buffer" }, -- text within current buffer
         { name = "path" }, -- file system paths
+		{ name = "cmp-adaptive-freq"}
       }),
       -- configure lspkind for vs-code like pictograms in completion menu
       formatting = {


### PR DESCRIPTION
I would like to start out by saying that I had a goal of making a neovim fork for writers, but before doing that I wanted to make an effort to make a neovim configuration that is very much writer focused. Hence my previous issue and this issue with regard to cmp-adaptive-freq. I like buffer complete because it's just likely that if you type a word you're going to type it again, but between a small context window, missing extra context from files within the same project, 0 syntax awareness I thought I could make something better and more writer focused. Something that doesn't suggest words that are smaller than 4 characters because as nvim users, we should type too fast for that to be useful. Something that can know about how we type globally so it doesn't have a useless feeling cold start. Something that prioritizes word frequency then word pairs, and then relation of the words we have previously typed. This is the nvim-cmp source cmp-adaptive-freq. 

https://github.com/TheShadowblast123/cmp-adaptive-freq

at this point there's only one breaking change I'm considering (using mpack over json) but it's pretty much done now. There's an argument to be had about removing cmp-buffer since technically they're accomplishing the same thing, but cmp-buffer requires less typing and less setup so I personally wouldn't suggest it. I have also made cmp-freq which is another source that supports multiple languages to give results strictly based on word frequency, but cmp-buffer is already fufilling the role that cmp-freq would fill.

I'm largely concerned with making writing poetry in nvim better and OVIwrite seems to be more novel/screenplay focused so there's only a few more ideas I have that feel compatible